### PR TITLE
Split version commands into subcommands

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Manage versions",
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cmd/version_list.go
+++ b/cmd/version_list.go
@@ -12,7 +12,7 @@ import (
 )
 
 var versionListCmd = &cobra.Command{
-	Use:   "version:list",
+	Use:   "list",
 	Short: "List all versions of an image",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := config.CreateConfig(configFile)
@@ -54,5 +54,5 @@ var versionListCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(versionListCmd)
+	versionCmd.AddCommand(versionListCmd)
 }

--- a/cmd/version_prune.go
+++ b/cmd/version_prune.go
@@ -7,7 +7,7 @@ import (
 )
 
 var versionPruneCmd = &cobra.Command{
-	Use:   "version:prune",
+	Use:   "prune",
 	Short: "Remove old versions of images",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := config.CreateConfig(configFile)
@@ -29,5 +29,5 @@ var versionPruneCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(versionPruneCmd)
+	versionCmd.AddCommand(versionPruneCmd)
 }


### PR DESCRIPTION
Split the `version:list` and `version:prune` commands into subcommands using Cobra.

* **cmd/version_list.go**
  - Change `Use` field value from `version:list` to `list`
  - Add `versionListCmd` to `versionCmd` instead of `rootCmd`

* **cmd/version_prune.go**
  - Change `Use` field value from `version:prune` to `prune`
  - Add `versionPruneCmd` to `versionCmd` instead of `rootCmd`

* **cmd/version.go**
  - Create a new `versionCmd` using `cobra.Command`
  - Add `versionCmd` to `rootCmd`
  - Add `version list` and `version prune` subcommands to `versionCmd`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shyim/tanjun?shareId=a29fdc2b-759d-48c5-97a5-d567319b02f4).