### PR TITLE
Refactor service container removal into a separate function

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "tasks": {
+    "build": "go build",
+    "test": "go test",
+    "launch": "go run ."
+  }
+}

--- a/internal/docker/service.go
+++ b/internal/docker/service.go
@@ -215,3 +215,15 @@ func startService(ctx context.Context, client *client.Client, name, containerNam
 
 	return nil
 }
+
+func stopAndRemoveContainer(ctx context.Context, client *client.Client, containerID string) error {
+	if err := client.ContainerStop(ctx, containerID, container.StopOptions{Timeout: nil}); err != nil {
+		return fmt.Errorf("failed to stop container (id: %s): %w", containerID, err)
+	}
+
+	if err := client.ContainerRemove(ctx, containerID, container.RemoveOptions{}); err != nil {
+		return fmt.Errorf("failed to delete container (id: %s): %w", containerID, err)
+	}
+
+	return nil
+}

--- a/internal/docker/service_memcached.go
+++ b/internal/docker/service_memcached.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/invopop/jsonschema"
 	"github.com/shyim/tanjun/internal/config"
@@ -32,12 +31,8 @@ func (m MemcachedService) Deploy(ctx context.Context, client *client.Client, ser
 			return nil
 		}
 
-		if err := client.ContainerStop(ctx, existingContainer.ID, container.StopOptions{Timeout: nil}); err != nil {
-			return fmt.Errorf("failed to stop service %s (id: %s): %w", serviceName, existingContainer.ID, err)
-		}
-
-		if err := client.ContainerRemove(ctx, existingContainer.ID, container.RemoveOptions{}); err != nil {
-			return fmt.Errorf("failed to delete service %s (id: %s): %w", serviceName, existingContainer.ID, err)
+		if err := stopAndRemoveContainer(ctx, client, existingContainer.ID); err != nil {
+			return fmt.Errorf("failed to stop and remove service %s (id: %s): %w", serviceName, existingContainer.ID, err)
 		}
 	}
 

--- a/internal/docker/service_mysql.go
+++ b/internal/docker/service_mysql.go
@@ -67,12 +67,8 @@ func (m MySQLService) Deploy(ctx context.Context, client *client.Client, service
 			return nil
 		}
 
-		if err := client.ContainerStop(ctx, existingContainer.ID, container.StopOptions{Timeout: nil}); err != nil {
-			return fmt.Errorf("failed to stop service %s (id: %s): %w", serviceName, existingContainer.ID, err)
-		}
-
-		if err := client.ContainerRemove(ctx, existingContainer.ID, container.RemoveOptions{}); err != nil {
-			return fmt.Errorf("failed to delete service %s (id: %s): %w", serviceName, existingContainer.ID, err)
+		if err := stopAndRemoveContainer(ctx, client, existingContainer.ID); err != nil {
+			return fmt.Errorf("failed to stop and remove service %s (id: %s): %w", serviceName, existingContainer.ID, err)
 		}
 	}
 

--- a/internal/docker/service_rabbitmq.go
+++ b/internal/docker/service_rabbitmq.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
 	"github.com/invopop/jsonschema"
@@ -41,12 +40,8 @@ func (v RabbitmqService) Deploy(ctx context.Context, client *client.Client, serv
 			return nil
 		}
 
-		if err := client.ContainerStop(ctx, existingContainer.ID, container.StopOptions{Timeout: nil}); err != nil {
-			return fmt.Errorf("failed to stop service %s (id: %s): %w", serviceName, existingContainer.ID, err)
-		}
-
-		if err := client.ContainerRemove(ctx, existingContainer.ID, container.RemoveOptions{}); err != nil {
-			return fmt.Errorf("failed to delete service %s (id: %s): %w", serviceName, existingContainer.ID, err)
+		if err := stopAndRemoveContainer(ctx, client, existingContainer.ID); err != nil {
+			return fmt.Errorf("failed to stop and remove service %s (id: %s): %w", serviceName, existingContainer.ID, err)
 		}
 	}
 

--- a/internal/docker/service_valkey.go
+++ b/internal/docker/service_valkey.go
@@ -38,12 +38,8 @@ func (v ValkeyService) Deploy(ctx context.Context, client *client.Client, servic
 			return nil
 		}
 
-		if err := client.ContainerStop(ctx, existingContainer.ID, container.StopOptions{Timeout: nil}); err != nil {
-			return fmt.Errorf("failed to stop service %s (id: %s): %w", serviceName, existingContainer.ID, err)
-		}
-
-		if err := client.ContainerRemove(ctx, existingContainer.ID, container.RemoveOptions{}); err != nil {
-			return fmt.Errorf("failed to delete service %s (id: %s): %w", serviceName, existingContainer.ID, err)
+		if err := stopAndRemoveContainer(ctx, client, existingContainer.ID); err != nil {
+			return fmt.Errorf("failed to stop and remove service %s (id: %s): %w", serviceName, existingContainer.ID, err)
 		}
 	}
 


### PR DESCRIPTION
Refactor code to stop and remove containers into a new function `stopAndRemoveContainer` and call it in relevant services.

* **internal/docker/service.go**
  - Add a new function `stopAndRemoveContainer` to stop and remove a container by its ID.

* **internal/docker/service_memcached.go**
  - Replace the code that stops and removes the container with a call to `stopAndRemoveContainer`.

* **internal/docker/service_mysql.go**
  - Replace the code that stops and removes the container with a call to `stopAndRemoveContainer`.

* **internal/docker/service_rabbitmq.go**
  - Replace the code that stops and removes the container with a call to `stopAndRemoveContainer`.

* **internal/docker/service_valkey.go**
  - Replace the code that stops and removes the container with a call to `stopAndRemoveContainer`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shyim/tanjun?shareId=ecad95fb-1ec8-4e72-9f2c-f3cee321db5a).