### PR TITLE
Fix code scanning alert no. 4: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -204,6 +204,12 @@ func downloadFromContainer(ctx context.Context, c *client.Client, containerId, r
 			return fmt.Errorf("failed to read next tar header: %w", err)
 		}
 
+		// Check for directory traversal sequences
+		if strings.Contains(header.Name, "..") {
+			log.Warnf("skipping potentially unsafe file path: %s", header.Name)
+			continue
+		}
+
 		targetPath := filepath.Join(local, header.Name)
 
 		switch header.Typeflag {


### PR DESCRIPTION
Fixes [https://github.com/shyim/tanjun/security/code-scanning/4](https://github.com/shyim/tanjun/security/code-scanning/4)

To fix the problem, we need to ensure that the `header.Name` does not contain any directory traversal sequences like `..` before using it to construct the `targetPath`. This can be achieved by checking if the `header.Name` contains `..` and skipping such entries if they do.

1. Add a check to ensure `header.Name` does not contain `..`.
2. If `header.Name` contains `..`, log a warning and skip the entry.
3. Ensure the rest of the code remains unchanged to maintain existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
